### PR TITLE
Send Telegram Messages when Bitbucket posts a failed/unknown build status comment

### DIFF
--- a/src/bitbucket.rs
+++ b/src/bitbucket.rs
@@ -310,7 +310,7 @@ impl Bitbucket {
                         // Have to post or edit comment
                         match Bitbucket::matching_comments_substring(&comments, &pr.from_commit) {
                             Some(comment) => {
-                                (self.edit_comment(pr.id, &comment, &text), "Edit")
+                                (self.edit_comment(pr.id, &comment, &text), "Update")
                             },
                             None => (self.post_comment(pr.id, &text), "Post")
                         }

--- a/src/bitbucket.rs
+++ b/src/bitbucket.rs
@@ -182,7 +182,12 @@ impl ::Repository for Bitbucket {
                         id: pr.id,
                         web_url: pr.links["self"][0].href.to_owned(),
                         from_ref: pr.fromRef.id.to_owned(),
-                        from_commit: pr.fromRef.latestCommit.to_owned()
+                        from_commit: pr.fromRef.latestCommit.to_owned(),
+                        title: pr.title.to_owned(),
+                        author: ::User {
+                            name: pr.author.user.displayName.to_owned(),
+                            email: pr.author.user.emailAddress.to_owned()
+                        }
                     }
                 }).collect())
             },

--- a/src/fanout.rs
+++ b/src/fanout.rs
@@ -161,7 +161,7 @@ mod tests {
     extern crate timebomb;
     use self::timebomb::timeout_ms;
     use super::{Fanout, Message, OpCode};
-    use super::super::PullRequest;
+    use super::super::{PullRequest, User};
 
     const TIMEOUT: u32 = 1000;
 
@@ -170,7 +170,12 @@ mod tests {
             id: 111,
             web_url: "http://www.foobar.com".to_owned(),
             from_ref: "abc".to_owned(),
-            from_commit: "ffffff".to_owned()
+            from_commit: "ffffff".to_owned(),
+            title: "A very important PR".to_owned(),
+            author: User {
+                name: "Aaron Xiao Ming".to_owned(),
+                email: "aaron@xiao.ming".to_owned()
+            }
         }
     }
 

--- a/src/fanout.rs
+++ b/src/fanout.rs
@@ -12,7 +12,8 @@ pub enum OpCode {
     BuildScheduled,
     BuildFinished { success: bool },
     BuildRunning,
-    BuildQueued
+    BuildQueued,
+    Custom { payload: String }
 }
 
 #[derive(RustcDecodable, RustcEncodable, PartialEq, Debug, Clone)]
@@ -31,6 +32,7 @@ impl Message {
     }
 }
 
+#[derive(Clone)]
 pub struct Fanout<T> where T : 'static + Send + Sync + Clone {
     broadcast_tx: Sender<T>,
     pub subscribers: Arc<Mutex<Vec<Sender<T>>>>

--- a/src/fanout.rs
+++ b/src/fanout.rs
@@ -1,5 +1,4 @@
 use std::collections::BTreeMap;
-use std::collections::btree_map::{Iter, IterMut};
 use std::sync::mpsc::{channel, Sender, Receiver};
 use std::sync::{Arc, Mutex};
 use std::thread::spawn;
@@ -80,14 +79,6 @@ impl JsonDictionary {
         }
     }
 
-    pub fn iter(&self) -> Iter<String, String> {
-        return self.dictionary.iter();
-    }
-
-    pub fn iter_mut(&mut self) -> IterMut<String, String> {
-        return self.dictionary.iter_mut();
-    }
-
     pub fn len(&self) -> usize {
         return self.dictionary.len();
     }
@@ -110,7 +101,6 @@ impl<T> Fanout<T>  where T : 'static + Send + Sync + Clone {
 
         let cloned_subscribers = subscribers.clone();
         spawn(move || {
-            println!("Broadcast loop");
             for message in broadcast_rx.iter() {
                 let subscribers_mutex = cloned_subscribers.lock();
                 if let Err(err) = subscribers_mutex {
@@ -223,5 +213,104 @@ mod tests {
         }, TIMEOUT);
 
         assert_eq!(fanout.subscribers.lock().unwrap().len(), 1);
+    }
+}
+
+#[cfg(test)]
+mod json_dictionary_tests {
+    use super::{JsonDictionary};
+    use rustc_serialize::{json, Decodable};
+
+    #[derive(RustcDecodable, RustcEncodable, PartialEq, Debug)]
+    struct Payload {
+        pub payload: String
+    }
+
+    #[derive(RustcDecodable, RustcEncodable, PartialEq, Debug)]
+    struct OtherPayload {
+        pub other: String
+    }
+
+    static EMPTY_JSON: &'static str = "{\"dictionary\":{}}";
+
+    fn make_payload() -> Payload {
+        Payload { payload: "foobar".to_owned() }
+    }
+
+    fn make_dictionary() -> JsonDictionary {
+        let mut dictionary = JsonDictionary::new();
+        dictionary.insert("payload", &make_payload())
+            .expect("Payload should be serializable");
+        dictionary
+    }
+
+    fn unwrap_from_json_dictionary<T>(dictionary: &JsonDictionary, key: &str)
+         -> T where T : Decodable {
+        match dictionary.get::<T>(key) {
+            Some(Ok(result)) => result,
+            _ => panic!("Unable to unwrap object")
+        }
+    }
+
+    #[test]
+    fn a_new_dictionary_is_created() {
+        let dictionary = JsonDictionary::new();
+        let actual_json = json::encode(&dictionary).unwrap();
+        assert_eq!(EMPTY_JSON, actual_json);
+    }
+
+    #[test]
+    fn clears_removes_all_items() {
+        let mut dictionary = make_dictionary();
+        dictionary.clear();
+        let actual_json = json::encode(&dictionary).unwrap();
+        assert_eq!(EMPTY_JSON, actual_json);
+    }
+
+    #[test]
+    fn gets_returns_a_deserialized_object() {
+        let dictionary = make_dictionary();
+        let object: Payload = unwrap_from_json_dictionary(&dictionary, &"payload");
+        assert_eq!(make_payload(), object);
+    }
+
+    #[test]
+    fn gets_returns_none_for_non_existing_keys() {
+        let dictionary = make_dictionary();
+        let object = dictionary.get::<Payload>("foobar");
+        assert_eq!(None, object);
+    }
+
+    #[test]
+    fn gets_returns_err_on_failed_deserialization() {
+        let dictionary = make_dictionary();
+        let object = dictionary.get::<OtherPayload>("payload").unwrap();
+        assert_eq!(object.is_err(), true);
+    }
+
+    #[test]
+    fn contains_keys_return_correctly() {
+        let dictionary = make_dictionary();
+        assert_eq!(dictionary.contains_key("payload"), true);
+        assert_eq!(dictionary.contains_key("foobar"), false);
+    }
+
+    #[test]
+    fn removes_removes_elements() {
+        let mut dictionary = make_dictionary();
+        assert_eq!(dictionary.remove("payload"), true);
+        assert_eq!(dictionary.remove("foobar"), false);
+        let actual_json = json::encode(&dictionary).unwrap();
+        assert_eq!(EMPTY_JSON, actual_json);
+    }
+
+    #[test]
+    fn empty_and_len_return_correct_values() {
+        let mut dictionary = make_dictionary();
+        assert_eq!(dictionary.len(), 1);
+        assert_eq!(dictionary.is_empty(), false);
+        assert_eq!(dictionary.remove("payload"), true);
+        assert_eq!(dictionary.len(), 0);
+        assert_eq!(dictionary.is_empty(), true);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,7 +32,7 @@ pub trait UsernameAndPassword {
     fn password(&self) -> &String;
 }
 
-#[derive(RustcEncodable, Eq, PartialEq, Clone, Debug)]
+#[derive(RustcEncodable, RustcDecodable, Eq, PartialEq, Clone, Debug)]
 pub struct PullRequest {
     pub id: i32,
     pub web_url: String,

--- a/src/main.rs
+++ b/src/main.rs
@@ -487,7 +487,7 @@ mod tests {
                 room: -1234567890i64
             }),
             run_interval: 999,
-            stdout_broadcast: false
+            stdout_broadcast: Some(false)
         };
 
         let json_string = read_config("tests/fixtures/config.json", Cursor::new("")).unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -338,7 +338,7 @@ fn check_build_status(pr: &PullRequest, build: &BuildDetails, repo: &Repository)
 #[cfg(test)]
 mod tests {
     use super::{bitbucket, teamcity, telegram, Config, PullRequest, ContinuousIntegrator, Build};
-    use super::{BuildDetails, BuildStatus, BuildState, Repository};
+    use super::{BuildDetails, BuildStatus, BuildState, Repository, User};
     use super::{read_config, parse_config, get_latest_build, schedule_build};
     use super::{check_build_status};
     use std::fs::File;
@@ -393,7 +393,12 @@ mod tests {
             id: 111,
             web_url: "http://www.foobar.com/pr/111".to_owned(),
             from_ref: "refs/heads/branch_name".to_owned(),
-            from_commit: "363c1dfda4cdf5a01c2d210e49942c8c8e7e898b".to_owned()
+            from_commit: "363c1dfda4cdf5a01c2d210e49942c8c8e7e898b".to_owned(),
+            title: "A very important PR".to_owned(),
+            author: User {
+                name: "Aaron Xiao Ming".to_owned(),
+                email: "aaron@xiao.ming".to_owned()
+            }
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,7 +38,9 @@ pub struct PullRequest {
     pub id: i32,
     pub web_url: String,
     pub from_ref: String,
-    pub from_commit: String
+    pub from_commit: String,
+    pub title: String,
+    pub author: User
 }
 
 impl PullRequest {
@@ -48,10 +50,10 @@ impl PullRequest {
     }
 }
 
-#[derive(RustcDecodable, Eq, PartialEq, Clone, Debug)]
-pub struct Comment {
-    pub id: i32,
-    pub text: String
+#[derive(RustcEncodable, RustcDecodable, Eq, PartialEq, Clone, Debug)]
+pub struct User {
+    pub name: String,
+    pub email: String
 }
 
 pub trait Repository {

--- a/src/rest.rs
+++ b/src/rest.rs
@@ -1,6 +1,5 @@
 use std::io::Read;
-use rustc_serialize;
-use rustc_serialize::json;
+use rustc_serialize::{json, Decodable};
 use hyper;
 use hyper::client::Client;
 use hyper::header::{Authorization, Basic, Accept, qitem, ContentType};
@@ -58,12 +57,12 @@ impl Headers {
 }
 
 pub fn get<T>(url: &str, headers: &hyper::header::Headers) -> Result<T, String>
-    where T: rustc_serialize::Decodable {
+    where T: Decodable {
     request(url, hyper::method::Method::Get, &None, headers, &hyper::status::StatusCode::Ok)
 }
 
 pub fn post<T>(url: &str, body: &str, headers: &hyper::header::Headers, status_code: &hyper::status::StatusCode)
-         -> Result<T, String> where T: rustc_serialize::Decodable {
+         -> Result<T, String> where T: Decodable {
     request(url, hyper::method::Method::Post, &Some(body.to_owned()), headers, status_code)
 }
 
@@ -73,7 +72,7 @@ pub fn post_raw(url: &str, body: &str, headers: &hyper::header::Headers)
 }
 
 pub fn put<T>(url: &str, body: &str, headers: &hyper::header::Headers, status_code: &hyper::status::StatusCode)
-         -> Result<T, String> where T: rustc_serialize::Decodable {
+         -> Result<T, String> where T: Decodable {
     request(url, hyper::method::Method::Put, &Some(body.to_owned()), headers, status_code)
 }
 
@@ -97,7 +96,7 @@ fn request<T>(url: &str,
               body: &Option<String>,
               headers: &hyper::header::Headers,
               status_code: &hyper::status::StatusCode)
-                    -> Result<T, String> where T: rustc_serialize::Decodable {
+                    -> Result<T, String> where T: Decodable {
     let mut response = match request_raw(url, method, body, headers) {
         Ok(response) => response,
         Err(err) => return Err(err.to_string())

--- a/src/telegram.rs
+++ b/src/telegram.rs
@@ -44,7 +44,7 @@ impl TelegramCredentials {
                             Some(text) => text,
                             None => "".to_owned()
                         };
-                        let message_text = format!("⚠ Tests for Pull Request #{} has failed\n{}\n{}\nBy {}\n{}\n{}",
+                        let message_text = format!("⚠ Tests for Pull Request #{} have failed\n{}\n{}\nBy {}\n{}\n{}",
                             pr.id, status_text, pr.title, pr.author.name, pr.web_url, build.web_url);
 
                         Self::send_message(&api, room, message_text);

--- a/src/telegram.rs
+++ b/src/telegram.rs
@@ -2,39 +2,72 @@ use std::sync::mpsc::Receiver;
 use std::thread;
 use std::time;
 use telegram_bot;
+use rustc_serialize::{json, Decodable};
 
-use fanout::{Message, OpCode};
+use fanout::{Message, OpCode, JsonDictionary};
 
 #[derive(RustcDecodable, Eq, PartialEq, Clone, Debug)]
 pub struct TelegramCredentials {
-    pub enabled: bool,
-    pub api_token: String,
-    pub room: i64
+	pub enabled: bool,
+	pub api_token: String,
+	pub room: i64
 }
 
 impl TelegramCredentials {
-  pub fn announce_from(&self, subscriber: Receiver<Message>) -> Result<(), String> {
-    let api = match telegram_bot::Api::from_token(self.api_token.as_str()) {
-      Ok(x) => x,
-      Err(err) => return Err(format!("{}", err))
-    };
+	pub fn announce_from(&self, subscriber: Receiver<Message>) -> Result<(), String> {
+		let api = match telegram_bot::Api::from_token(self.api_token.as_str()) {
+			Ok(x) => x,
+			Err(err) => return Err(format!("{}", err))
+		};
 
-    let room = self.room;
+		let room = self.room;
 
-    thread::spawn(move ||
-      for message in subscriber.iter() {
-        match message.opcode {
-          OpCode::BuildFinished { success: false } => {
-            if let Err(err) = api.send_message(room, message.payload, None, None, None, None) {
-              println!("{}", err)
-            }
-            thread::sleep(time::Duration::new(1, 0))
-          },
-          _ => {} // noop
-        }
-      }
-    );
+		thread::spawn(move || {
+			let telegram_sleep_duration = time::Duration::new(1, 0);
+			for message in subscriber.iter() {
+				match message.opcode {
+					OpCode::Custom { payload: ref custom_payload }
+						if custom_payload == "Bitbucket::Comment::Update"
+							|| custom_payload == "Bitbucket::Comment::Post" => {
+						// panic if payload cannot be deserialized
+						let dictionary: JsonDictionary = json::decode(&message.payload).unwrap();
+						// should panic if the deserialization failed
+						let build = Self::unwrap_from_json_dictionary::<::BuildDetails>(&dictionary, "build").unwrap();
+						if build.state != ::BuildState::Finished || build.status == ::BuildStatus::Success {
+							continue;
+						}
 
-    Ok(())
-  }
+						// should panic if the deserialization failed
+						let pr = Self::unwrap_from_json_dictionary::<::PullRequest>(&dictionary, "pr").unwrap();
+
+						let status_text = match build.status_text {
+							Some(text) => text,
+							None => "".to_owned()
+						};
+						let message_text = format!("❌ Tests for Pull Request #{} has failed: {}\nPR: {}\nBuild: {}",
+							pr.id, status_text, pr.web_url, build.web_url);
+
+						Self::send_message(&api, room, message_text);
+						thread::sleep(telegram_sleep_duration);
+					}
+					_ => {} // noop
+				};
+			}
+		});
+		Ok(())
+	}
+
+	fn send_message(api: &telegram_bot::Api, room: i64, message: String) {
+		if let Err(err) = api.send_message(room, message, None, None, None, None) {
+			println!("{}", err)
+		}
+	}
+
+	fn unwrap_from_json_dictionary<T>(dictionary: &JsonDictionary, key: &str)
+	 	-> Result<T, ()> where T : Decodable {
+		match dictionary.get::<T>(key) {
+			Some(Ok(result)) => Ok(result),
+			_ => Err(())
+		}
+	}
 }

--- a/src/telegram.rs
+++ b/src/telegram.rs
@@ -33,7 +33,7 @@ impl TelegramCredentials {
                         let dictionary: JsonDictionary = json::decode(&message.payload).unwrap();
                         // should panic if the deserialization failed
                         let build = Self::unwrap_from_json_dictionary::<::BuildDetails>(&dictionary, "build").unwrap();
-                        if build.state != ::BuildState::Finished  {
+                        if build.state != ::BuildState::Finished  || build.status == ::BuildStatus::Success {
                             continue;
                         }
 

--- a/src/telegram.rs
+++ b/src/telegram.rs
@@ -33,7 +33,7 @@ impl TelegramCredentials {
                         let dictionary: JsonDictionary = json::decode(&message.payload).unwrap();
                         // should panic if the deserialization failed
                         let build = Self::unwrap_from_json_dictionary::<::BuildDetails>(&dictionary, "build").unwrap();
-                        if build.state != ::BuildState::Finished || build.status == ::BuildStatus::Success {
+                        if build.state != ::BuildState::Finished  {
                             continue;
                         }
 
@@ -44,8 +44,8 @@ impl TelegramCredentials {
                             Some(text) => text,
                             None => "".to_owned()
                         };
-                        let message_text = format!("❌ Tests for Pull Request #{} has failed: {}\nPR: {}\nBuild: {}",
-                            pr.id, status_text, pr.web_url, build.web_url);
+                        let message_text = format!("⚠ Tests for Pull Request #{} has failed\n{}\n{}\nBy {}\n{}\n{}",
+                            pr.id, status_text, pr.title, pr.author.name, pr.web_url, build.web_url);
 
                         Self::send_message(&api, room, message_text);
                         thread::sleep(telegram_sleep_duration);

--- a/src/telegram.rs
+++ b/src/telegram.rs
@@ -8,66 +8,66 @@ use fanout::{Message, OpCode, JsonDictionary};
 
 #[derive(RustcDecodable, Eq, PartialEq, Clone, Debug)]
 pub struct TelegramCredentials {
-	pub enabled: bool,
-	pub api_token: String,
-	pub room: i64
+    pub enabled: bool,
+    pub api_token: String,
+    pub room: i64
 }
 
 impl TelegramCredentials {
-	pub fn announce_from(&self, subscriber: Receiver<Message>) -> Result<(), String> {
-		let api = match telegram_bot::Api::from_token(self.api_token.as_str()) {
-			Ok(x) => x,
-			Err(err) => return Err(format!("{}", err))
-		};
+    pub fn announce_from(&self, subscriber: Receiver<Message>) -> Result<(), String> {
+        let api = match telegram_bot::Api::from_token(self.api_token.as_str()) {
+            Ok(x) => x,
+            Err(err) => return Err(format!("{}", err))
+        };
 
-		let room = self.room;
+        let room = self.room;
 
-		thread::spawn(move || {
-			let telegram_sleep_duration = time::Duration::new(1, 0);
-			for message in subscriber.iter() {
-				match message.opcode {
-					OpCode::Custom { payload: ref custom_payload }
-						if custom_payload == "Bitbucket::Comment::Update"
-							|| custom_payload == "Bitbucket::Comment::Post" => {
-						// panic if payload cannot be deserialized
-						let dictionary: JsonDictionary = json::decode(&message.payload).unwrap();
-						// should panic if the deserialization failed
-						let build = Self::unwrap_from_json_dictionary::<::BuildDetails>(&dictionary, "build").unwrap();
-						if build.state != ::BuildState::Finished || build.status == ::BuildStatus::Success {
-							continue;
-						}
+        thread::spawn(move || {
+            let telegram_sleep_duration = time::Duration::new(1, 0);
+            for message in subscriber.iter() {
+                match message.opcode {
+                    OpCode::Custom { payload: ref custom_payload }
+                        if custom_payload == "Bitbucket::Comment::Update"
+                            || custom_payload == "Bitbucket::Comment::Post" => {
+                        // panic if payload cannot be deserialized
+                        let dictionary: JsonDictionary = json::decode(&message.payload).unwrap();
+                        // should panic if the deserialization failed
+                        let build = Self::unwrap_from_json_dictionary::<::BuildDetails>(&dictionary, "build").unwrap();
+                        if build.state != ::BuildState::Finished || build.status == ::BuildStatus::Success {
+                            continue;
+                        }
 
-						// should panic if the deserialization failed
-						let pr = Self::unwrap_from_json_dictionary::<::PullRequest>(&dictionary, "pr").unwrap();
+                        // should panic if the deserialization failed
+                        let pr = Self::unwrap_from_json_dictionary::<::PullRequest>(&dictionary, "pr").unwrap();
 
-						let status_text = match build.status_text {
-							Some(text) => text,
-							None => "".to_owned()
-						};
-						let message_text = format!("❌ Tests for Pull Request #{} has failed: {}\nPR: {}\nBuild: {}",
-							pr.id, status_text, pr.web_url, build.web_url);
+                        let status_text = match build.status_text {
+                            Some(text) => text,
+                            None => "".to_owned()
+                        };
+                        let message_text = format!("❌ Tests for Pull Request #{} has failed: {}\nPR: {}\nBuild: {}",
+                            pr.id, status_text, pr.web_url, build.web_url);
 
-						Self::send_message(&api, room, message_text);
-						thread::sleep(telegram_sleep_duration);
-					}
-					_ => {} // noop
-				};
-			}
-		});
-		Ok(())
-	}
+                        Self::send_message(&api, room, message_text);
+                        thread::sleep(telegram_sleep_duration);
+                    }
+                    _ => {} // noop
+                };
+            }
+        });
+        Ok(())
+    }
 
-	fn send_message(api: &telegram_bot::Api, room: i64, message: String) {
-		if let Err(err) = api.send_message(room, message, None, None, None, None) {
-			println!("{}", err)
-		}
-	}
+    fn send_message(api: &telegram_bot::Api, room: i64, message: String) {
+        if let Err(err) = api.send_message(room, message, None, None, None, None) {
+            println!("{}", err)
+        }
+    }
 
-	fn unwrap_from_json_dictionary<T>(dictionary: &JsonDictionary, key: &str)
-	 	-> Result<T, ()> where T : Decodable {
-		match dictionary.get::<T>(key) {
-			Some(Ok(result)) => Ok(result),
-			_ => Err(())
-		}
-	}
+    fn unwrap_from_json_dictionary<T>(dictionary: &JsonDictionary, key: &str)
+         -> Result<T, ()> where T : Decodable {
+        match dictionary.get::<T>(key) {
+            Some(Ok(result)) => Ok(result),
+            _ => Err(())
+        }
+    }
 }

--- a/tests/fixtures/config.json
+++ b/tests/fixtures/config.json
@@ -18,5 +18,6 @@
     "api_token": "XXX:XXXX",
     "room": "-1234567890"
   },
-  "run_interval": 999
+  "run_interval": 999,
+  "stdout_broadcast": false
 }


### PR DESCRIPTION
 - Implement a `JsonDictionary` to wrap multiple `Encodable`s in a `fanout::Message` `payload
 - Add a `Custom` `OpCode`
 - Make Bitbucket broadcast a `Custom` event on comment handling

TODO:
- [x] Write Tests for `JsonDictionary`